### PR TITLE
Check tx batch index and l1 block number 

### DIFF
--- a/minigeth/core/state_processor.go
+++ b/minigeth/core/state_processor.go
@@ -299,20 +299,20 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	return receipts, allLogs, *usedGas, nil
 }
 
-func getEonKeyFromContract(e *vm.EVM, eonKeyContract common.Address, blockNumber *big.Int) (*shcrypto.EonPublicKey, error) {
+func getEonKeyFromContract(e *vm.EVM, eonKeyContract common.Address, blockNumber uint64) (*shcrypto.EonPublicKey, error) {
 	caller := vm.AccountRef(common.Address{})
 
-	callData, err := eonKeyStorageABI.Pack("get", blockNumber.Uint64())
+	callData, err := eonKeyStorageABI.Pack("get", blockNumber)
 	if err != nil {
 		return nil, err
 	}
 	result, _, err := e.Call(caller, eonKeyContract, callData, 1000000, common.Big0)
 	if err != nil {
-		log.Printf("failed to find eon key for block #%s: %s", blockNumber, err)
+		log.Printf("failed to find eon key for block #%d: %s", blockNumber, err)
 		return nil, nil
 	}
 	if len(result) == 0 {
-		log.Printf("no eon key available for block #%s", blockNumber)
+		log.Printf("no eon key available for block #%d", blockNumber)
 		return nil, nil
 	}
 
@@ -361,13 +361,13 @@ func getBatchIndex(e *vm.EVM, batchCounterContract common.Address) (uint64, erro
 // getCollatorAddress returns the address configured as the collator in the collator config
 // contract for the given L1 block number. If the contract hasn't been deployed yet, it returns
 // nil.
-func getCollatorAddress(e *vm.EVM, collatorConfigContract common.Address, blockNumber *big.Int) (*common.Address, error) {
+func getCollatorAddress(e *vm.EVM, collatorConfigContract common.Address, blockNumber uint64) (*common.Address, error) {
 	if e.StateDB.GetCodeSize(collatorConfigContract) == 0 {
 		return nil, nil
 	}
 
 	caller := vm.AccountRef(common.Address{})
-	configData, err := collatorConfigABI.Pack("getActiveConfig", blockNumber.Uint64())
+	configData, err := collatorConfigABI.Pack("getActiveConfig", blockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/minigeth/core/state_processor.go
+++ b/minigeth/core/state_processor.go
@@ -204,6 +204,15 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 				return nil, nil, 0, fmt.Errorf("could not extract signer of tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 			}
 
+			if tx.BatchIndex() != batchTx.BatchIndex() {
+				return nil, nil, 0, fmt.Errorf("invalid tx %d [%v]: batch index mismatch between shutter tx and batch (%d != %d)",
+					i, tx.Hash(), tx.BatchIndex(), batchTx.BatchIndex())
+			}
+			if tx.L1BlockNumber() != batchTx.L1BlockNumber() {
+				return nil, nil, 0, fmt.Errorf("invalid tx %d [%v]: l1 block number mismatch between shutter tx and batch (%d != %d)",
+					i, tx.Hash(), tx.L1BlockNumber(), batchTx.L1BlockNumber())
+			}
+
 			if tx.Gas() < params.TxGas {
 				return nil, nil, 0, fmt.Errorf("invalid tx %d [%v]: tx gas lower than minimum (%v < %v)", i, tx.Hash(), tx.Gas(), params.TxGas)
 			}

--- a/minigeth/core/state_processor_test.go
+++ b/minigeth/core/state_processor_test.go
@@ -28,8 +28,8 @@ var (
 	config                = params.TestChainConfig
 	genesisHash           = common.HexToHash("0xd702d0441aa0045ac875b526e6ea7064e67604ef2162034a9b7260540f3e9f25")
 	signer                types.Signer
-	defaultBaseFee        = new(big.Int).SetUint64(1_000_000_000) // 1 GWei
-	activationBlockNumber = big.NewInt(100)
+	defaultBaseFee               = new(big.Int).SetUint64(1_000_000_000) // 1 GWei
+	activationBlockNumber uint64 = 100
 
 	deployerKey      *ecdsa.PrivateKey
 	deployerAddress  common.Address
@@ -157,7 +157,7 @@ func makeBatchTx(t *testing.T, statedb *state.StateDB, transactions []*types.Tra
 	return makeBatchTxWithBlockNumber(t, statedb, activationBlockNumber, transactions)
 }
 
-func makeBatchTxWithBlockNumber(t *testing.T, statedb *state.StateDB, blockNumber *big.Int, transactions []*types.Transaction) *types.Transaction {
+func makeBatchTxWithBlockNumber(t *testing.T, statedb *state.StateDB, blockNumber uint64, transactions []*types.Transaction) *types.Transaction {
 	batchIndex := getBatchIndexTesting(t, statedb)
 	txBytes := [][]byte{}
 	for _, tx := range transactions {
@@ -313,7 +313,7 @@ func deployCollatorConfig(t *testing.T, statedb *state.StateDB) {
 	addConfigArgs, err := collatorConfigABI.Pack("addNewCfg", struct {
 		ActivationBlockNumber uint64
 		SetIndex              uint64
-	}{activationBlockNumber.Uint64(), 1})
+	}{activationBlockNumber, 1})
 	fatalIfError(t, err)
 	unsignedAddConfigTx := &types.DynamicFeeTx{
 		ChainID:   config.ChainID,
@@ -327,7 +327,7 @@ func deployCollatorConfig(t *testing.T, statedb *state.StateDB) {
 	}
 	addConfigTx, err := types.SignNewTx(deployerKey, signer, unsignedAddConfigTx)
 	fatalIfError(t, err)
-	addConfigBatchTx := makeBatchTxWithBlockNumber(t, statedb, common.Big0, []*types.Transaction{addConfigTx})
+	addConfigBatchTx := makeBatchTxWithBlockNumber(t, statedb, 0, []*types.Transaction{addConfigTx})
 	addConfigReceipts, _, _, err := processBatchTx(t, statedb, addConfigBatchTx)
 	fatalIfError(t, err)
 	assertTxsSuccessful(t, addConfigReceipts, 1)
@@ -845,7 +845,7 @@ func TestWrongBatchIndex(t *testing.T) {
 		ChainID:       config.ChainID,
 		DecryptionKey: decryptionKeys[batchIndex].Marshal(),
 		BatchIndex:    batchIndex,
-		L1BlockNumber: common.Big0,
+		L1BlockNumber: 0,
 		Timestamp:     common.Big0,
 		Transactions:  [][]byte{},
 	}


### PR DESCRIPTION
Reject batches if they contain a shutter tx whose batch index or l1 block number does not match the corresponding values in the batch.